### PR TITLE
Small change left over from previous project

### DIFF
--- a/src/ye_of_rho.F90
+++ b/src/ye_of_rho.F90
@@ -144,7 +144,7 @@ contains
           yeinlogrho(i) = yeinlogrho(i-1)
        endif
        do while ((j.lt.(plen+1)).and.proceed)
-          if (profilerho(j).gt.rhoinlogrho(i)) then
+          if (profilerho(j).ge.rhoinlogrho(i)) then
              proceed = .false.
              !set ye it interpolated value between next profile rho and last one
              if (j.eq.1) then
@@ -160,7 +160,7 @@ contains
           j=j+1
        enddo
        if (j.eq.(plen+1).and.proceed) then
-          write(*,*) "Error",i
+          write(*,*) "Error",i, rhoinlogrho(i), profilerho(plen)
           stop
        endif
     enddo


### PR DESCRIPTION
Given the M1 capabilities of the code, I'm not sure you'll keep using Ye(rho), but this fixes a tiny issue I had when reading in Ye(rho) profiles. I also have a commit in there that I got from you as an email attachment (M1 implicit timestepping fix). Github does not see any difference between our codes in that area, so I presume you must have committed the same file yourself.