### PR TITLE
changed nanchecker for residuals matrix to be more robust and modern

### DIFF
--- a/src/M1/M1_implicitstep.F90
+++ b/src/M1/M1_implicitstep.F90
@@ -1069,7 +1069,7 @@ subroutine M1_implicitstep(dts,implicit_factor)
            stop "You need to have matrix inversion software" 
 #endif
 
-           if (sum(RF).ne.sum(RF)) then
+           if (isnan(sum(RF))) then
               write(*,*) k,i,nt
               write(*,*) NL_jacobian
               write(*,*) 


### PR DESCRIPTION
As suggested by Evan, the condition on the nanchecking for RF was modernized to work with different compilers. Checked with the intel compilers and this works now while the old method did not.