### PR TITLE
couple GR1D with STIR

### DIFF
--- a/sample_parameter_files/latest_recommended_params
+++ b/sample_parameter_files/latest_recommended_params
@@ -122,3 +122,8 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)
+alpha_turb              =       1.0     # MLT parameter for turbulence
+tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
+

--- a/sample_parameter_files/latest_recommended_params
+++ b/sample_parameter_files/latest_recommended_params
@@ -124,6 +124,3 @@ do_rotation		=	0	# 1 for 1D rotation
 
 ###### Turbulence #######
 do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)
-alpha_turb              =       1.0     # MLT parameter for turbulence
-tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
-

--- a/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_implicitPP_explicitNES_params
+++ b/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_implicitPP_explicitNES_params
@@ -118,3 +118,5 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)

--- a/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_implicitPP_implicitNES_params
+++ b/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_implicitPP_implicitNES_params
@@ -118,3 +118,5 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)

--- a/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_noNNBrem_params
+++ b/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_noNNBrem_params
@@ -117,3 +117,5 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)

--- a/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_params
+++ b/sample_parameter_files/oconnor2015_taggedversion_params/s15WW95_params
@@ -118,3 +118,5 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)

--- a/sample_parameter_files/oconnor2015_taggedversion_params/s40WH07_params
+++ b/sample_parameter_files/oconnor2015_taggedversion_params/s40WH07_params
@@ -117,3 +117,5 @@ atmo_fac		=	0.1d0
 ####### Rotation #######
 do_rotation		=	0	# 1 for 1D rotation
 
+###### Turbulence #######
+do_turbulence           =       0       # 1 for turbulence of Boccioli et al. (2021)

--- a/sample_parameter_files/turbulence_recommended_params
+++ b/sample_parameter_files/turbulence_recommended_params
@@ -125,7 +125,6 @@ do_rotation		=	0	# 1 for 1D rotation
 
 ###### Turbulence #######
 do_turbulence           =       1       # 1 for turbulence of Couch et al. (2019)
-evolve_turbulence       =       1       # 1 to evolve v_turb in time, 0 for simple MLT
 alpha_turb              =       1.0     # MLT parameter for turbulence
 tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
 

--- a/sample_parameter_files/turbulence_recommended_params
+++ b/sample_parameter_files/turbulence_recommended_params
@@ -124,7 +124,7 @@ atmo_fac		=	0.1d0
 do_rotation		=	0	# 1 for 1D rotation
 
 ###### Turbulence #######
-do_turbulence           =       1       # 1 for turbulence of Couch et al. (2019)
-alpha_turb              =       1.5     # MLT parameter for turbulence
-tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
+do_turbulence           =       1       # 1 for turbulence of Boccioli et al. (2021)
+alpha_turb              =       1.5d0   # MLT parameter for turbulence
+tpb_for_turbulence      =       -1.0d0  # time post bounce after which you want to turn on turbulence (-1 if you want it always on)
 

--- a/sample_parameter_files/turbulence_recommended_params
+++ b/sample_parameter_files/turbulence_recommended_params
@@ -125,6 +125,6 @@ do_rotation		=	0	# 1 for 1D rotation
 
 ###### Turbulence #######
 do_turbulence           =       1       # 1 for turbulence of Couch et al. (2019)
-alpha_turb              =       1.0     # MLT parameter for turbulence
+alpha_turb              =       1.5     # MLT parameter for turbulence
 tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
 

--- a/sample_parameter_files/turbulence_recommended_params
+++ b/sample_parameter_files/turbulence_recommended_params
@@ -1,0 +1,131 @@
+##### Job parameters #######
+jobname			=	"GR1Dv2 s15 transport run"
+GR			=	1		# 1 for GR, 0 for Newtonian
+outdir 			= 	"s15WW95"
+initial_data		=	"Collapse"	# "Sedov", "Shocktube", "OSC", "Collapse", "M1test"
+profile_name		=	"./profiles/s15s7b2.approx.short" # stellar profile
+WHW02profile		=	1		# 1 for WHW02/HW07/WW95 profile (adjust radius definition)
+profile_type		=	1		# 1: .short format
+gravity_active		=	1		# do we want gravity?
+ntmax			=	100000000	# maximum timestep
+tend			=	0.7d0		# maximum time
+
+
+####### Grid parameters #######
+geometry		=	2		# 1: planar, 2: spherical
+gridtype		=	"custom"		# "log", "unigrid", "custom", "custom2"
+### custom & custom2 input parameters ###
+grid_custom_rad1	=	20.0d5		# radial extent of custom grid (log outside)
+grid_custom_dx1		=	3.0d4		# smallest radial zone
+
+rmax_from_profile	=	1		# take rmax to be where rho=3.0d3g/cm^3
+rho_cut 		=	2.0d3		# density to cut profile at if rmax_from_profile = 1
+
+radial_zones		=	600		# number of radial zones
+ghosts1			=	4		# number of ghost cells
+
+
+####### Hydro Parameters #######
+do_hydro		=	1		# 1 for hydro on
+iorder_hydro		=	2		# RK order for hydro 
+cffac			=	0.5d0		# CFL factor
+reconstruction_method	=	"ppm"		# "tvd", "pc","ppm"
+ppm_origin_TVD		=	5		
+tvd_limiter		=	"MC"		# MC, minmod,
+flux_type		= 	"HLLE"		# HLLE
+
+####### EOS parameters #######
+eoskey			=	3		# hybrid: 1
+						# poly: 2
+						# hot nuclear: 3
+						# ideal: 4
+eos_table_name 		= 	"LS180_234r_136t_50y_analmu_20091212_SVNr26.h5"
+hybridgamma_th		=	1.30d0		# hybrid gamma_th
+hybridgamma1		=	1.31d0		# hybrid gamma_th
+hybridgamma2		=	2.40d0		# hybrid gamma_th
+
+####### Output parameters #######
+ntinfo			=	100		# stdout
+dynamic_output_control  = 	1		# use output_control.F90
+vs_mass			=	0		# output .xg files vs mass_bary
+small_output		=	0		# used to limit .xg files
+dtout			=	1.0d-3		# time between outputs
+dtout_scalar		=	1.0d-4		# time between scalar out
+ntout			=	-1		# output every timesteps
+ntout_scalar		=	-1		# scalar output
+
+
+####### Restart parameters #######
+ntout_restart		=	-1		# restart output frequency in timesteps
+dtout_restart		=	0.005d0		# restart output frequency in time
+do_restart 		= 	0
+restart_file_name	=	""
+read_v_turb             =       0               # 1 if you are restarting from a simulation that includes turbulence, 0 otherwise
+force_restart_dump	=	0		# keep this 0 to maintain output frequency, 1 forces output at start
+
+########## M1 settings ##########
+do_M1		 	=       1			#1 for M1 transport scheme
+v_order			=	-1
+evolution_radii		=	6.0d7			#radii to evolve neutrinos out to
+extraction_radii	=	5.0d7			#radii to extract neutrinos from
+number_species		=	3			#number of neutrino species, limited 
+							#options will work, must be comensurate with table
+number_groups		=	18			#number of energy groups, limited 
+							#options will work, must be comensurate with table
+opacity_table 		=	"NuLib_LS180_noweak_rho82_temp65_ye51_ng18_ns3_Itemp65_Ieta61_version1.0_20141111.h5"
+number_eas		=	3			#number of opacity variables to read in
+M1closure		=	'ME'
+testcase		=	0			#if you want a test case set this to the
+							#test case number, along with M1test as "initial_data"
+include_epannihil_kernels =	0			#for full nux thermal treatment
+include_nes_kernels	= 	1			#to read in inelastic neutrino electron scattering kernels
+nes_evolution_type	=	1			#0: no nes, 1: explicit nes, 2: implicit nes
+energycoupling_evolution_type =	1			#0: no coupling, 1: explicit coupling, 2: implicit coupling
+
+
+M1_control		=	1			#1 means you must specify the settings for each phase
+							# in the parameter file, collapse, bounce and postbounce.	
+
+M1_phase1phase2_density =	1.0d12			#central density to switch to phase 2
+M1_phase2phase3_pbtime  =	0.02d0			#post bounce time to switch to phase3
+
+M1_phase1_reconstruction =	'tvd'			#reconstruction method for both matter and neutrinos (phase1 must match above)
+M1_phase2_reconstruction =	'ppm'
+M1_phase3_reconstruction =	'ppm'
+
+M1_phase1_cffac 	=	0.5d0			#CFL factor, typically needs to be reduced near bounce
+M1_phase2_cffac 	=	0.2d0			
+M1_phase3_cffac		=	0.5d0
+
+M1_phase1_ns		=	1			#number of species to evolve
+M1_phase2_ns		=	3
+M1_phase3_ns		=	3
+
+M1_phase1_ies_way	=	1			#0 is none, 1 is explicit inelastic scattering, 2 is implicit (phase1 must match above)
+M1_phase2_ies_way	=	2			
+M1_phase3_ies_way	=	1
+
+M1_phase1_encpl_way	=	1			#0 is none, 1 is explicit energycoupling, 2 is implicit (phase1 must match above)
+M1_phase2_encpl_way	=	1			
+M1_phase3_encpl_way	=	1
+
+do_M1_extra_heating	=	0
+M1_heat_fac		=	1.0d0
+
+####### Neutrino parameters #######
+fake_neutrinos		=	0		# 1 for ANY fake neutrino scheme
+
+####### Atmosphere parameters #######
+atmo_rho_rel_min	=	0.0d0
+atmo_rho_abs_min	=	1.5d3
+atmo_fac		=	0.1d0
+
+####### Rotation #######
+do_rotation		=	0	# 1 for 1D rotation
+
+###### Turbulence #######
+do_turbulence           =       1       # 1 for turbulence of Couch et al. (2019)
+evolve_turbulence       =       1       # 1 to evolve v_turb in time, 0 for simple MLT
+alpha_turb              =       1.0     # MLT parameter for turbulence
+tpb_for_turbulence      =       -1.0d0   # time post bounce after which turn turbulence on (-1 if you want it always on)
+

--- a/src/GR1D_module.F90
+++ b/src/GR1D_module.F90
@@ -145,6 +145,26 @@ module GR1D_module
   real*8 internal_energy
   real*8,allocatable,save :: ToverW(:)
 
+  !turbulence, nomenclature from Couch et al. 2020
+  logical :: do_turbulence = .false. 
+  logical :: activate_turbulence = .false.
+  logical :: read_v_turb = .false. !this is for restart purposes
+  logical :: explosion_reached = .false.
+  real*8 :: alpha_turb, tpb_for_turbulence
+  real*8,allocatable,save :: omega2_BV(:)
+  real*8,allocatable,save :: v_turb(:)
+  
+  real*8,allocatable,save :: diff_term_eps(:)
+  real*8,allocatable,save :: diff_term_ye(:)
+  real*8,allocatable,save :: diff_term_K(:)
+    
+  real*8,allocatable,save :: turb_source(:,:)
+  real*8,allocatable,save :: lambda_mlt(:), shear(:), diss(:), buoy(:)
+  real*8,parameter :: alpha_turb_e = 1.0/6.0
+  real*8,parameter :: alpha_turb_ye = 1.0/6.0
+  real*8,parameter :: alpha_turb_K = 1.0/6.0
+  real*8,parameter :: alpha_turb_nu = 1.0/6.0
+
   !testcases variables
   integer :: shocktube_problem
 
@@ -215,7 +235,8 @@ module GR1D_module
   real*8,allocatable,save :: v(:),vm(:),vp(:)
   real*8,allocatable,save :: v_prev(:)
   real*8,allocatable,save :: vphi(:),vphim(:),vphip(:)
-
+  ! added for turbulence
+  real*8,allocatable,save :: v_turbp(:),v_turbm(:)
   ! #######################################################
 
   ! radial coordinate 

--- a/src/M1/M1_implicitstep.F90
+++ b/src/M1/M1_implicitstep.F90
@@ -1168,10 +1168,9 @@ subroutine M1_implicitstep(dts,implicit_factor)
                        
                        !second time in here, make flux implicit
                        if (trouble_brewing) then
-                          sourceG(problem_zone,3) = q_M1_old(k,i,problem_zone,1) + &
-                               D_M1(k,i,j,1)
+                          sourceG(problem_zone,3) = q_M1_old(k,i,problem_zone,1)
                           sourceG(problem_zone,1) = sourceG(problem_zone,1) - &
-                               B_M1(k,i,problem_zone,1)/q_M1_old(k,i,problem_zone,1)
+                               ( D_M1(k,i,j,1) + B_M1(k,i,j,1) )/q_M1_old(k,i,problem_zone,1)
                           changedtwice = .true.
                        endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 include ../make.inc
 
 SOURCES=GR1D_module.F90 \
+	grad_module.F90 \
 	timers.F90 \
 	GR1D.F90 \
 	atmosphere.F90 \
@@ -36,6 +37,7 @@ SOURCES=GR1D_module.F90 \
 	analysis.F90 \
 	neutrino_pressure.F90 \
 	start.F90 \
+	turbulence.F90 \
 	M1/M1_init.F90 \
 	M1/M1_reconstruct.F90 \
 	M1/M1_closure.F90 \

--- a/src/Step.F90
+++ b/src/Step.F90
@@ -26,19 +26,19 @@ subroutine Step(dts)
 
   ! Is it time to turn on turbulence?
   if (do_turbulence) then
-      if (tpb_for_turbulence .lt. 0.0d0) then
-         activate_turbulence = .true.
-      else if (bounce) then
-		 if (time .gt. t_bounce + tpb_for_turbulence) then
-			activate_turbulence = .true.
-		 else 
-		    activate_turbulence = .false.  
-		 endif
-	  else 
-         activate_turbulence = .false.
-      endif
+     if (tpb_for_turbulence .lt. 0.0d0) then
+        activate_turbulence = .true.
+     else if (bounce) then
+        if (time .gt. t_bounce + tpb_for_turbulence) then
+           activate_turbulence = .true.
+        else 
+           activate_turbulence = .false.  
+        endif
+     else 
+        activate_turbulence = .false.
+     endif
   endif
- 
+
   !If the shock reaches the outer boundary you can safely assume that the SN exploded
   if ( (shock_radius .ge. x1(n1-ghosts1-1)) .or. &
        (shock_radius/length_gf .ge. 15000.0d5) .and. .not. explosion_reached) then

--- a/src/allocate_vars.F90
+++ b/src/allocate_vars.F90
@@ -25,6 +25,21 @@ subroutine allocate_vars
   endif
   allocate(ToverW(n1))
 
+  if(do_turbulence) then
+     allocate(omega2_BV(n1))
+     allocate(v_turb(n1))
+     allocate(v_turbp(n1))
+     allocate(v_turbm(n1))
+     allocate(diff_term_eps(n1))     
+     allocate(diff_term_ye(n1))
+     allocate(diff_term_K(n1))
+     allocate(turb_source(n1,n_cons))
+     allocate(lambda_mlt(n1))
+     allocate(shear(n1))
+     allocate(diss(n1))
+     allocate(buoy(n1))
+  endif
+
   allocate(v(n1))
   allocate(vp(n1))
   allocate(vm(n1))

--- a/src/boundaries.F90
+++ b/src/boundaries.F90
@@ -62,7 +62,12 @@ subroutine boundaries(innerflag,outerflag)
            vphi1p(i) = -vphi1m(gi)
            vphi1m(i) = -vphi1p(gi)
         endif
-
+        if(activate_turbulence) then
+           ! follow what's done for ye since we deal with a mass scalar (i.e. rho*v_turb^2)
+           v_turb(i) = v_turb(gi)
+           v_turbm(i) = v_turbm(gi)
+           v_turbp(i) = v_turbp(gi)
+        endif
      enddo
   else
      gi=ghosts1+1
@@ -162,7 +167,14 @@ subroutine boundaries(innerflag,outerflag)
         vphi1m(i) = vphi1(gi)
         vphi1p(i) = vphi1(gi)
      endif
-
+     if(activate_turbulence) then
+        ! follow what's done for ye since we deal with a mass scalar (i.e. v_turb^2)    
+        v_turbp(gi) = v_turb(gi)
+        v_turb(i) = v_turb(gi)
+        v_turbm(i) = v_turb(gi)
+        v_turbp(i) = v_turb(gi)
+     endif
+     
   enddo
   
 end subroutine boundaries

--- a/src/con2prim.F90
+++ b/src/con2prim.F90
@@ -72,6 +72,10 @@ subroutine con2prim_1
         low_tol = tol
         ye(i) = q(i,4)/q(i,1)
 
+        if (activate_turbulence) then
+            v_turb(i) = sqrt(q(i,6)/q(i,1))
+        endif
+
         if (q(i,1).eq.0.0d0) then
            v1(i) = 0.0d0
            v(i) = 0.0d0
@@ -211,6 +215,10 @@ subroutine con2prim_1
         err = 1.0d0
         low_tol = tol
         ye(i) = q(i,4)/q(i,1)
+
+        if (activate_turbulence) then
+            v_turb(i) = sqrt(q(i,6)/q(i,1))
+        endif
 
         if (q(i,1).eq.0.0d0) then
            ! D = 0, set everything to zero in this case (can't be good)
@@ -385,7 +393,9 @@ subroutine con2prim_1
       endif
       
       ye(iminb:imaxb) = q(iminb:imaxb,4)/q(iminb:imaxb,1)
-
+      if (activate_turbulence) then
+         v_turb(iminb:imaxb) = sqrt(q(iminb:imaxb,6)/q(iminb:imaxb,1))
+      endif
    endif
    
    ! a few checks
@@ -449,6 +459,10 @@ subroutine con2prim_pt(tol,i,success)
   if (GR) then
      err = 1.0d0
      ye(i) = q(i,4)/q(i,1)
+
+     if (activate_turbulence) then
+        v_turb(i) = sqrt(q(i,6)/q(i,1))
+     endif     
 
      it = 0
      do while (err.gt.tol.and.it.lt.max_iterations)
@@ -570,7 +584,11 @@ subroutine con2prim_pt_rot(tol,i,success)
 
   if (GR) then
      ye(i) = q(i,4)/q(i,1)
-     
+   
+     if (activate_turbulence) then
+        v_turb(i) = sqrt(q(i,6)/q(i,1))
+     endif
+   
      ! general case
      it = 0
      op(i) = press(i)

--- a/src/flux_differences_HLLE.F90
+++ b/src/flux_differences_HLLE.F90
@@ -108,8 +108,8 @@ subroutine flux_differences_hlle
            fluxr(i,2) = fluxr(i,2) + qm(i+1,6)
            fluxr(i,3) = fluxr(i,3) + qm(i+1,6)*vm(i+1) 
            
-		   fluxl(i,6) = qp(i,6)*vp(i)
-		   fluxr(i,6) = qm(i+1,6)*vm(i+1)
+	   fluxl(i,6) = qp(i,6)*vp(i)
+	   fluxr(i,6) = qm(i+1,6)*vm(i+1)
         endif  
      else
         fluxl(i,1) = qp(i,1)*v1p(i)
@@ -134,8 +134,8 @@ subroutine flux_differences_hlle
            fluxr(i,2) = fluxr(i,2) + qm(i+1,6)
            fluxr(i,3) = fluxr(i,3) + qm(i+1,6)*v1m(i+1) 
            
-		   fluxl(i,6) = qp(i,6)*v1p(i) 
-		   fluxr(i,6) = qm(i+1,6)*v1m(i+1) 
+	   fluxl(i,6) = qp(i,6)*v1p(i) 
+	   fluxr(i,6) = qm(i+1,6)*v1m(i+1) 
         endif     
      endif
   enddo
@@ -224,6 +224,6 @@ subroutine flux_differences_hlle
   
   call cpu_time(t2)
 
-!  t_fdhlle = t_fdhlle + (t2-t1)
+  t_fdhlle = t_fdhlle + (t2-t1)
   
 end subroutine flux_differences_hlle

--- a/src/flux_differences_HLLE.F90
+++ b/src/flux_differences_HLLE.F90
@@ -100,7 +100,17 @@ subroutine flux_differences_hlle
            fluxl(i,5) = qp(i,5)*vp(i)
            fluxr(i,5) = qm(i+1,5)*vm(i+1)
         endif
-        
+      
+        if(activate_turbulence) then
+           fluxl(i,2) = fluxl(i,2) + qp(i,6)
+           fluxl(i,3) = fluxl(i,3) + qp(i,6)*vp(i) 
+           
+           fluxr(i,2) = fluxr(i,2) + qm(i+1,6)
+           fluxr(i,3) = fluxr(i,3) + qm(i+1,6)*vm(i+1) 
+           
+		   fluxl(i,6) = qp(i,6)*vp(i)
+		   fluxr(i,6) = qm(i+1,6)*vm(i+1)
+        endif  
      else
         fluxl(i,1) = qp(i,1)*v1p(i)
         fluxl(i,2) = qp(i,2)*v1p(i) + pressp(i)
@@ -117,6 +127,16 @@ subroutine flux_differences_hlle
            fluxr(i,5) = qm(i+1,5)*v1m(i+1)
         endif
         
+        if(activate_turbulence) then
+           fluxl(i,2) = fluxl(i,2) + qp(i,6)
+           fluxl(i,3) = fluxl(i,3) + qp(i,6)*v1p(i) 
+           
+           fluxr(i,2) = fluxr(i,2) + qm(i+1,6)
+           fluxr(i,3) = fluxr(i,3) + qm(i+1,6)*v1m(i+1) 
+           
+		   fluxl(i,6) = qp(i,6)*v1p(i) 
+		   fluxr(i,6) = qm(i+1,6)*v1m(i+1) 
+        endif     
      endif
   enddo
 
@@ -134,6 +154,11 @@ subroutine flux_differences_hlle
              * ( qm(i+1,m) - qp(i,m) ) ) &
              / ( dspeed(i) )
      enddo
+     if(activate_turbulence) then
+        flux(i,3) = flux(i,3) - diff_term_eps(i)
+        flux(i,4) = flux(i,4) - diff_term_ye(i)
+        flux(i,6) = flux(i,6) - diff_term_K(i)
+     endif
   enddo
 
   ! update by flux differencing
@@ -199,6 +224,6 @@ subroutine flux_differences_hlle
   
   call cpu_time(t2)
 
-  t_fdhlle = t_fdhlle + (t2-t1)
+!  t_fdhlle = t_fdhlle + (t2-t1)
   
 end subroutine flux_differences_hlle

--- a/src/grad_module.F90
+++ b/src/grad_module.F90
@@ -1,0 +1,191 @@
+module Grad_module
+
+  use GR1D_module, only: ghosts1, n1
+  implicit none
+  public
+
+contains
+
+function Gradient(var,r) result(grad)
+ 
+  real*8 var(n1),r(n1)
+  integer i
+  real*8 grad(n1), dumgrad
+
+  grad(:) = 0.0d0
+  ! calculate derivativees with standard gradient formula
+  !do i=ghosts1+2,n1-ghosts1-1
+  !   grad(i) = (var(i+1) - var(i-1))/(r(i+1) - r(i-1))
+  !enddo
+  
+  ! calculate derivatives with the 3 point formula
+  do i=ghosts1+2,n1-ghosts1-1
+     grad(i) = var(i+1)*(r(i)-r(i-1))/((r(i+1)-r(i-1))*(r(i+1)-r(i))) &
+             + var(i)*(r(i+1)-2.0d0*r(i)+r(i-1))/((r(i+1)-r(i))*(r(i)-r(i-1))) &
+             - var(i-1) * (r(i+1)-r(i))/((r(i)-r(i-1))*(r(i+1)-r(i-1))) 
+  enddo
+  
+  ! calculate one-sided derivatives
+  grad(ghosts1+1) = (var(ghosts1+2) - var(ghosts1+1))/ &
+                  (r(ghosts1+2) - r(ghosts1+1))
+
+  grad(n1-ghosts1) = (var(n1-ghosts1) - var(n1-ghosts1-1))/ &
+                     (r(n1-ghosts1) - r(n1-ghosts1-1))
+
+end function Gradient 
+
+function Gradient_3pts(var,r) result(grad)
+
+  real*8 var(n1),r(n1)
+  integer i
+  real*8 grad(n1)
+  real*8 h1,h2
+
+  grad(:) = 0.0d0
+  
+  ! calculate derivatives with the 3 point formula
+  do i=ghosts1+2,n1-ghosts1-1
+     
+     h1 = r(i)   - r(i-1)
+     h2 = r(i+1) - r(i)
+    
+     grad(i) = - var(i-1)*(h2/(h1*(h1+h2))) &
+               + var(i  )*((h2-h1)/(h1*h2)) &
+               + var(i+1)*((h1/(h2*(h1+h2))))
+  
+  enddo
+                    
+  ! calculate one-sided derivatives
+  grad(ghosts1+1) = (var(ghosts1+2) - var(ghosts1+1))/ &
+                  (r(ghosts1+2) - r(ghosts1+1))
+
+  grad(n1-ghosts1) = (var(n1-ghosts1) - var(n1-ghosts1-1))/ &
+                     (r(n1-ghosts1) - r(n1-ghosts1-1))
+
+end function Gradient_3pts
+
+function Gradient_5pts(var,r) result(grad)
+
+  real*8 var(n1),r(n1)
+  integer i
+  real*8 grad(n1)
+  real*8 h1,h2,h3,h4,Ht1,Ht2
+
+  grad(:) = 0.0d0
+  
+  ! calculate derivatives with the 5 point formula
+  do i=ghosts1+3,n1-ghosts1-2
+     
+     h1 = r(i-1) - r(i-2)
+     h2 = r(i)   - r(i-1)
+     h3 = r(i+1) - r(i)
+     h4 = r(i+2) - r(i+1)
+     Ht1 = h1+h2+h3
+     Ht2 = Ht1+h4
+    
+     grad(i) = var(i-2)*(h2*h3*(h3+h4))/(h1*(h1+h2)*Ht1*Ht2) &
+             - var(i-1)*((h1+h2)*h3*(h3+h4))/(h1*h2*(h2+h3)*(Ht2-h1)) &
+             + var(i)*((h1+2.0d0*h2)*h3*(h3+h4)-(h1+h2)*h2*(2.0d0*h3+h4)) &
+                     /((h1+h2)*h2*h3*(h3+h4)) &
+             + var(i+1)*((h2+h1)*h2*(h3+h4))/(Ht1*(h2+h3)*h3*h4) &
+             - var(i+2)*(h2*(h1+h2)*h3)/(Ht2*(Ht2-h1)*(h3+h4)*h4)
+
+  enddo
+  
+  ! simple 2 points far away from the shock should suffice
+  grad(ghosts1+2) = (var(ghosts1+3) - var(ghosts1+1))/ &
+                  (r(ghosts1+3) - r(ghosts1+1))
+  grad(n1-ghosts1-1) = (var(n1-ghosts1) - var(n1-ghosts1-2))/ &
+                     (r(n1-ghosts1) - r(n1-ghosts1-2))
+                     
+  ! calculate one-sided derivatives
+  grad(ghosts1+1) = (var(ghosts1+2) - var(ghosts1+1))/ &
+                  (r(ghosts1+2) - r(ghosts1+1))
+
+  grad(n1-ghosts1) = (var(n1-ghosts1) - var(n1-ghosts1-1))/ &
+                     (r(n1-ghosts1) - r(n1-ghosts1-1))
+
+end function Gradient_5pts
+ 
+function Gradient_int(var,radius) result(grad)
+
+  real*8, intent(in) :: var(n1),radius(n1)
+  integer i
+  real*8 grad(n1)
+  
+  grad(:) = 0.0d0
+  ! calculate derivatives
+  do i=ghosts1+1,n1-ghosts1-1
+     grad(i) = (var(i+1) - var(i))/(radius(i+1) - radius(i))
+  enddo
+
+  grad(n1-ghosts1) = grad(n1-ghosts1-1)
+
+end function Gradient_int
+
+subroutine QuadraticInterpolation1D(xOld, yOld, nX, &
+                                 X_New, Y_new)
+
+  real*8, intent(out)   :: Y_New
+  real*8, intent(in)    :: X_New
+  real*8, intent(in)    :: xOld(nX)
+  real*8, intent(in)    :: yOld(nX)
+  integer, intent(in)     :: nX
+
+  integer  :: i
+  real*8 :: L2_0, L2_1, L2_2
+
+  if (X_New <= xOld(1)) then
+
+    !Extrapolate DOwn
+    Y_New = yOld(1) - (xOld(1) - X_New) * (yOld(2) - yOld(1)) &
+                                          / (xOld(2) - xOld(1))
+
+    return
+
+  else if ( X_New <= xOld(2) ) then
+
+    Y_New = yOld(1) + (X_New    - xOld(1)) &
+                     * (yOld(2) - yOld(1)) &
+                     / (xOld(2) - xOld(1))
+
+  else if (X_New >= xOld(nX)) then
+
+    !Exptrapolate up
+    Y_New = yOld(nX) + (X_New - xOld(nX)) * (yOld(nX) - yOld(nX-1)) &
+                                            / (xOld(nX) - xOld(nX-1))
+    return
+
+  else if ( X_New >= xOld(nX-1) ) then
+
+    Y_New = yOld(nX-1) + (X_New     - xOld(nX-1)) &
+                        * (yOld(nX) - yOld(nX-1)) &
+                        / (xOld(nX) - xOld(nX-1))
+
+  else
+
+    do i = 1,nX
+
+      if( xOld(i) >= X_New ) then
+
+        L2_0 = ( (X_New      - xOld(i)) * (X_New      - xOld(i+1)) ) / &
+               ( (xOld(i-1) - xOld(i)) * (xOld(i-1) - xOld(i+1)) )
+        L2_1 = ( (X_New    - xOld(i-1)) * (X_New    - xOld(i+1)) ) / &
+               ( (xOld(i) - xOld(i-1)) * (xOld(i) - xOld(i+1)) )
+
+        L2_2 = ( (X_New      - xOld(i-1)) * (X_New      - xOld(i)) ) / &
+               ( (xOld(i+1) - xOld(i-1)) * (xOld(i+1) - xOld(i)) )
+
+        Y_New = yOld(i-1)*L2_0 + yOld(i)*L2_1 + yOld(i+1)*L2_2
+
+        return
+
+      end if
+
+    end do
+
+  end if
+
+end subroutine QuadraticInterpolation1D
+
+end module Grad_module

--- a/src/gravity.F90
+++ b/src/gravity.F90
@@ -36,6 +36,7 @@ subroutine con2GR
   real*8 nuE(n1)
   integer iminb,imaxb
   real*8 discrim
+  real*8 turbE(n1)
 
   iminb = ghosts1+1
   imaxb = n1-1
@@ -50,10 +51,16 @@ subroutine con2GR
      nuE(:) = (W(:)**2-1.0d0)*press_nu(:) + W(:)**2*energy_nu(:)
   endif
 
+  if (activate_turbulence) then
+     turbE(:) = q(:,6)
+  else
+     turbE(:) = 0.0d0
+  endif
+  
   !find new GR quantities
-  mgrav1(iminb) = (q(iminb,3)+q(iminb,1)+nuE(iminb))*volume(iminb)
+  mgrav1(iminb) = (q(iminb,3)+q(iminb,1)+nuE(iminb)+turbE(iminb))*volume(iminb)
   mgrav(iminb) = mgrav1(iminb) - 4.0d0/3.0d0*pi*(q(iminb,3) &
-       +q(iminb,1)+nuE(iminb)) * ( x1i(iminb+1)**3 - x1(iminb)**3 ) 
+       +q(iminb,1)+nuE(iminb)+turbE(iminb)) * ( x1i(iminb+1)**3 - x1(iminb)**3 ) 
   mgravi(iminb) = 0.0d0
   discrim = 1.0d0 - 2.0d0*mgrav(iminb)/x1(iminb)
   if (discrim.lt.0.0d0) then
@@ -61,12 +68,12 @@ subroutine con2GR
   endif
   X(iminb) = 1.0d0/sqrt(discrim)
   do i=iminb+1,imaxb
-     mgrav1(i) = (q(i,3)+q(i,1)+nuE(i))*volume(i)
+     mgrav1(i) = (q(i,3)+q(i,1)+nuE(i)+turbE(i))*volume(i)
      mgrav(i) = mgrav(i-1) + mgrav1(i) - 4.0d0/3.0d0*pi*(q(i,3)+q(i,1)+ &
-          nuE(i)) *( x1i(i+1)**3 - x1(i)**3 ) + &
-          4.0d0/3.0d0*pi*(q(i-1,3)+q(i-1,1)+nuE(i-1)) &
+          nuE(i)+turbE(i)) *( x1i(i+1)**3 - x1(i)**3 ) + &
+          4.0d0/3.0d0*pi*(q(i-1,3)+q(i-1,1)+nuE(i-1)+turbE(i-1)) &
           * ( x1i(i)**3 - x1(i-1)**3 )    
-     mgravi(i) = mgravi(i-1) + (q(i-1,3)+q(i-1,1)+nuE(i-1))*volume(i-1)
+     mgravi(i) = mgravi(i-1) + (q(i-1,3)+q(i-1,1)+nuE(i-1)+turbE(i-1))*volume(i-1)
      discrim = 1.0d0 - 2.0d0*mgrav(i)/x1(i)
      if (discrim.lt.0.0d0) then
         stop "We have a black hole"

--- a/src/initialize_vars.F90
+++ b/src/initialize_vars.F90
@@ -58,6 +58,7 @@ subroutine initialize_vars
   opacity_table = ""
   M1closure = 'ME'
   M1_testcase_number = 0
+  totalmass = 0.0d0
   total_energy_radiated = 0.0d0
   total_energy_absorped = 0.0d0
   total_net_heating = 0.0d0
@@ -83,7 +84,7 @@ subroutine initialize_vars
   ToverW(:) = 0.0d0
 
   eoskey = 0
-  
+ 
   initial_data = " "
 
   geometry = 0
@@ -177,6 +178,21 @@ subroutine initialize_arrays
      omega(:) = 0.0d0
   endif
 
+  if(do_turbulence) then
+     omega2_BV(:) = 0.0d0
+     v_turb(:) = 0.0d0
+     v_turbp(:) = 0.0d0
+     v_turbm(:) = 0.0d0
+     diff_term_eps(:) = 0.0d0
+     diff_term_ye(:) = 0.0d0
+     diff_term_K(:) = 0.0d0        
+     turb_source(:,:) = 0.0d0
+     lambda_mlt(:) = 0.0d0
+     shear(:) = 0.0d0
+     diss(:) = 0.0d0
+     buoy(:) = 0.0d0
+  endif
+  
   v(:) = 0.0d0
   vp(:) = 0.0d0
   vm(:) = 0.0d0

--- a/src/input_parser.F90
+++ b/src/input_parser.F90
@@ -6,7 +6,7 @@ subroutine input_parser
   implicit none
 
   integer :: tempint
-  
+        
   call get_string_parameter('jobname',jobname)
   call get_string_parameter('outdir',outdir)
   call get_logical_parameter('GR',GR)
@@ -272,7 +272,7 @@ subroutine input_parser
   if(do_restart) then
      call get_string_parameter('restart_file_name',restart_file_name)
      call get_logical_parameter('force_restart_dump',force_restart_output)
-     call get_logical_parameter('read_v_turb',read_v_turb)
+     if(do_turbulence) call get_logical_parameter('read_v_turb',read_v_turb)
   endif
 
 contains
@@ -351,7 +351,8 @@ contains
    write(6,*) "Fatal problem in input parser:"
    write(6,*) "Parameter ",parname
    write(6,*) "could not be read!"
-   write(6,*) 
+   write(6,*)
+
    call flush(6)
    stop
 

--- a/src/input_parser.F90
+++ b/src/input_parser.F90
@@ -261,11 +261,18 @@ subroutine input_parser
         omega_A = omega_A*length_gf
         omega_c = omega_c/time_gf
      endif
+     call get_logical_parameter('do_turbulence',do_turbulence)
+     if (do_turbulence) then
+  	     if (geometry.ne.2) stop "Turbulence in 1D?"
+        call get_double_parameter('alpha_turb',alpha_turb)
+        call get_double_parameter('tpb_for_turbulence',tpb_for_turbulence)
+     endif
   endif
      
   if(do_restart) then
      call get_string_parameter('restart_file_name',restart_file_name)
      call get_logical_parameter('force_restart_dump',force_restart_output)
+     call get_logical_parameter('read_v_turb',read_v_turb)
   endif
 
 contains
@@ -280,7 +287,7 @@ contains
    integer isokay
    character*(200) temp_string
 
-   open(unit=27,file='parameters',status='unknown')
+   open(unit=27,file=input_file,status='unknown')
 
 10 continue
    read(27,'(a)',end=19) line_string

--- a/src/map_profile.F90
+++ b/src/map_profile.F90
@@ -2,6 +2,7 @@
 subroutine map_profile(lprofile_name)
 
   use GR1D_module
+  use grad_module, only: QuadraticInterpolation1D
   implicit none
 
   character*(*) lprofile_name
@@ -17,7 +18,7 @@ subroutine map_profile(lprofile_name)
        ppress(:),peps(:),pvel(:),&
        pye(:),pomega(:)
 
-  real*8,allocatable,save :: pradius_new(:)
+  real*8,allocatable,save :: pradius_new(:), pvel_new(:)
   
   real*8 :: kboltz_cgs = 1.380662d-16
   
@@ -63,11 +64,17 @@ subroutine map_profile(lprofile_name)
 
   if (WHW02) then
      allocate(pradius_new(profile_zones))
+     allocate(pvel_new(profile_zones))
      pradius_new(1) = pradius(1)/2.0d0
      do i=2,profile_zones
         pradius_new(i) = (pradius(i)+pradius(i-1))/2.0d0
      enddo
+     do i=1,profile_zones
+       call QuadraticInterpolation1D(pradius, pvel, profile_zones,&
+           pradius_new(i), pvel_new(i))
+     enddo
      pradius(:) = pradius_new(:)
+     pvel(:) = pvel_new(:)
      !end of suggested code
   endif
 

--- a/src/output.F90
+++ b/src/output.F90
@@ -77,6 +77,21 @@ subroutine output_all(modeflag)
         endif
      endif
      
+     if (do_turbulence) then
+        filename = trim(adjustl(outdir))//"/omega2_BV.xg"
+        call output_single(omega2_BV*time_gf**2,filename)
+        filename = trim(adjustl(outdir))//"/v_turb.xg"
+        call output_single(v_turb*time_gf/length_gf,filename)
+        filename = trim(adjustl(outdir))//"/dissipated_turb_eps.xg"
+        if (.not. small_output) call output_single(diss*time_gf/eps_gf,filename)
+        filename = trim(adjustl(outdir))//"/buoyancy_turb_eps.xg"
+        if (.not. small_output) call output_single(buoy*time_gf/eps_gf,filename)     
+        filename = trim(adjustl(outdir))//"/shear_turb_eps.xg"
+        if (.not. small_output) call output_single(shear*time_gf/eps_gf,filename)     
+        filename = trim(adjustl(outdir))//"/Lambda_MLT.xg"
+        if (.not. small_output) call output_single(lambda_mlt/length_gf,filename)     
+     endif
+	 
      filename = trim(adjustl(outdir))//"/rho.xg"
      call output_single(rho/rho_gf,filename)
      

--- a/src/prim2con.F90
+++ b/src/prim2con.F90
@@ -29,13 +29,17 @@ subroutine prim2con_1
         if(do_rotation) then
            q(i,5) = rho(i)*h*W(i)**2*vphi(i)*x1(i)
         endif
+        
+        if(activate_turbulence) then
+           q(i,6) = X(i)*W(i)*rho(i)*v_turb(i)**2
+        endif
      enddo
   else 
      !Newtonian
      do i=1,n1
         q(i,1) = rho(i)
         q(i,2) = rho(i)*v1(i)
-        q(i,3) = rho(i)*eps(i) + 0.5d0*rho(i)*v1(i)**2 
+        q(i,3) = rho(i)*eps(i) + 0.5d0*rho(i)*v1(i)**2
         if(do_rotation) then
            q(i,3) = q(i,3) + 0.5d0*rho(i)*twothirds*vphi1(i)**2
         endif
@@ -47,6 +51,12 @@ subroutine prim2con_1
         enddo
      endif
 
+     if(activate_turbulence) then
+       ! you might have to add something to turbulence in case of rotation ???
+       do i=1,n1
+           q(i,6) = rho(i)*v_turb(i)**2
+        enddo
+     endif
   endif
   
 end subroutine prim2con_1
@@ -80,6 +90,10 @@ subroutine prim2con_if
            qm(i,5) = rhom(i) * hm * Wm(i)**2 * vphim(i) * x1i(i)
         endif
 
+        if(activate_turbulence) then
+           qp(i,6) = Xp(i) * Wp(i) * rhop(i) * v_turbp(i)**2
+           qm(i,6) = Xm(i) * Wm(i) * rhom(i) * v_turbm(i)**2
+        endif
      enddo
   else 
      !Newtonian
@@ -101,6 +115,10 @@ subroutine prim2con_if
            qm(i,3) = qm(i,3) + 0.5d0*rhom(i)*twothirds*vphi1m(i)**2 
         endif
 
+        if(activate_turbulence) then
+           qp(i,6) = rhop(i) * v_turbp(i)**2
+           qm(i,6) = rhom(i) * v_turbm(i)**2 
+        endif
      enddo
   endif
   

--- a/src/reconstruct.F90
+++ b/src/reconstruct.F90
@@ -90,6 +90,14 @@ subroutine reconstruct_with_pc
         endif
      endif
 
+     ! not sure if I have to do stuff worrying about GR active,
+     ! I don't think so since we are dealing with a mass scalar
+     
+     if (activate_turbulence) then
+        v_turbm(i) = v_turb(i)
+        v_turbp(i) = v_turb(i)
+     endif
+
      if (GR) then
         if (do_rotation) then
            discrim = 1.0d0-vp(i)**2-twothirds*vphip(i)**2
@@ -146,6 +154,13 @@ subroutine reconstruct_with_tvd
      else
         call tvd_reconstruction(n1,ghosts1,vphi1,vphi1p,vphi1m,tvd_limiter)
      endif
+  endif
+
+  ! not sure if I have to do stuff worrying about GR active,
+  ! I don't think so since we are dealing with a mass scalar
+  
+  if (activate_turbulence) then
+     call tvd_reconstruction(n1,ghosts1,v_turb,v_turbp,v_turbm,tvd_limiter)
   endif
 
   if (GR) then
@@ -230,6 +245,12 @@ subroutine reconstruct_with_ppm
      endif
   endif
 
+  ! not sure if I have to do stuff worrying about GR active,
+  ! I don't think so since we are dealing with a mass scalar
+  if (activate_turbulence) then
+     call ppm_interpolate(v_turb,v_turbp,v_turbm)
+  endif
+
   call ppm_flatten
 
   call ppm_monotonize(rho,rhop,rhom)
@@ -257,6 +278,10 @@ subroutine reconstruct_with_ppm
            vphi1m(i) = ppmomegam(i)*x1i(i)
         enddo
      endif
+  endif
+
+  if (activate_turbulence) then
+     call ppm_monotonize(v_turb,v_turbp,v_turbm)
   endif
 
   cv = 0.0d0

--- a/src/restart_H5.F90
+++ b/src/restart_H5.F90
@@ -537,7 +537,17 @@ subroutine restart_output_h5
   call h5sclose_f(dspace_id, error)
   cerror = cerror + error
 #endif
-     
+   
+  if (do_turbulence) then
+     call h5screate_simple_f(rank, dims1, dspace_id, error)
+     call h5dcreate_f(file_id, "v_turb", H5T_NATIVE_DOUBLE, dspace_id,&
+          & dset_id, error)
+     call h5dwrite_f(dset_id, H5T_NATIVE_DOUBLE, v_turb, dims1, error)
+     call h5dclose_f(dset_id, error)
+     call h5sclose_f(dspace_id, error)
+     cerror = cerror + error
+  endif
+   
   if (do_nupress.or.do_M1) then
      call h5screate_simple_f(rank, dims1, dspace_id, error)
      call h5dcreate_f(file_id, "press_nu", H5T_NATIVE_DOUBLE,&
@@ -1082,6 +1092,13 @@ subroutine restart_init_h5
   cerror = cerror + error
 #endif
 
+  if (do_turbulence .and. read_v_turb) then
+     call h5dopen_f(file_id, "v_turb", dset_id, error)
+     call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, v_turb, dims1, error)
+     call h5dclose_f(dset_id,error)
+     cerror = cerror + error
+  endif
+
   if (do_nupress.or.do_M1) then
      call h5dopen_f(file_id, "press_nu", dset_id, error)
      call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, press_nu, dims1, error)
@@ -1109,7 +1126,8 @@ subroutine restart_init_h5
      
      rank=2
      dims2(1) = n1
-     dims2(2) = 4
+     ! with turbulence n_cons is always 6
+     dims2(2) = 6
      
      if (dims2(2).ne.n_cons) stop "add other conservative to neutrinos, and restart file"
 

--- a/src/restart_H5.F90
+++ b/src/restart_H5.F90
@@ -1126,11 +1126,8 @@ subroutine restart_init_h5
      
      rank=2
      dims2(1) = n1
-     ! with turbulence n_cons is always 6
-     dims2(2) = 6
+     dims2(2) = 4
      
-     if (dims2(2).ne.n_cons) stop "add other conservative to neutrinos, and restart file"
-
      call h5dopen_f(file_id, "M1_matter_source", dset_id, error)
      call h5dread_f(dset_id, H5T_NATIVE_DOUBLE, M1_matter_source, dims2, error)
      call h5dclose_f(dset_id,error) 

--- a/src/start.F90
+++ b/src/start.F90
@@ -12,9 +12,15 @@ subroutine start
   character(len=128) rmstring
   logical :: outdirthere
 
+  call getarg(1,input_file)
   write(*,*) "Parsing input file..."
+  
   !this time to get details of arrays sizes etc
   call input_parser
+
+  if (do_turbulence .and. do_rotation) then
+    stop 'Not yet tested with both rotation and turbulence! :/'
+  endif
 
   if(eoskey.eq.3) then
 #if HAVE_NUC_EOS
@@ -28,12 +34,8 @@ subroutine start
   !total zones
   n1 = radial_zones+ghosts1*2
 
-  if(do_rotation) then
-     n_cons = 5
-  else
-     n_cons = 4
-  endif
-
+  n_cons = 6
+  
   !allocate & initialize variables
   call allocate_vars
   call initialize_vars
@@ -61,7 +63,8 @@ subroutine start
   rmstring="rm -rf "//trim(adjustl(outdir))//"/*"
   call system(rmstring)
   ! copy parameter file
-  cpstring="cp parameters "//trim(adjustl(outdir))
+  cpstring="cp "//trim(adjustl(input_file))//" "//trim(adjustl(outdir)) &
+      //"/parameters"
   call system(cpstring)
 
   !setting up initial data

--- a/src/start.F90
+++ b/src/start.F90
@@ -11,8 +11,15 @@ subroutine start
   character(len=128) cpstring
   character(len=128) rmstring
   logical :: outdirthere
+  integer :: num_args
 
-  call getarg(1,input_file)
+  num_args = command_argument_count()
+  if ( num_args .eq. 0 ) then
+    input_file = "parameters"
+  else
+    call getarg(1,input_file)
+  endif
+
   write(*,*) "Parsing input file..."
   
   !this time to get details of arrays sizes etc

--- a/src/turbulence.F90
+++ b/src/turbulence.F90
@@ -1,0 +1,134 @@
+!-*-f90-*-
+subroutine turb_diff_terms
+
+   use GR1D_module, only: x1, eps, ye, v_turb, alpha_turb, &
+     alpha_turb_K, alpha_turb_e, alpha_turb_ye, dphidr, rhop, &
+     pressp, v_turbp, qp, diff_term_eps, diff_term_ye, &
+     diff_term_K, n1, ghosts1
+   use Grad_module
+   implicit none
+
+   integer:: i
+   real*8 :: Lambda_mixp
+   real*8 :: D_turb_eps, D_turb_ye, D_turb_K
+   real*8 :: eps_grad(n1), ye_grad(n1), v2_turb_grad(n1)
+
+   eps_grad = Gradient_int(eps,x1)
+   ye_grad = Gradient_int(ye,x1)
+   v2_turb_grad = Gradient_int(v_turb**2,x1)
+   
+   !Implement the calculation of the diffusion terms
+   do i=ghosts1+1,n1-ghosts1
+      Lambda_mixp = alpha_turb * pressp(i) / (rhop(i) * dphidr(i))
+      Lambda_mixp = min(Lambda_mixp,x1(i))
+      
+      ! Calculate diffusion coefficients as given in Couch et al. 2019 eqs. 29-31
+      D_turb_eps = alpha_turb_e * v_turbp(i) * Lambda_mixp
+      D_turb_ye = alpha_turb_ye * v_turbp(i) * Lambda_mixp
+      D_turb_K = alpha_turb_K * v_turbp(i) * Lambda_mixp
+   
+      diff_term_eps(i) = qp(i,1) * D_turb_eps * eps_grad(i)
+      diff_term_ye(i) = qp(i,1) * D_turb_ye * ye_grad(i)
+      diff_term_K(i) = qp(i,1) * D_turb_K * v2_turb_grad(i)
+   enddo 
+
+end subroutine turb_diff_terms
+
+subroutine turbulence_sources
+
+   use GR1D_module, only: x1, GR, v_turb, omega2_BV, v1, &
+     alpha_turb, dphidr, press, rho, n1, ghosts1, turb_source, &
+     alp, X, shear, diss, buoy, sqrt_gamma, ishock
+   use Grad_module
+   implicit none
+
+   integer i
+   real*8 Lambda_mix
+   real*8 v_grad(n1)
+   
+   v_grad = Gradient_5pts(v1,x1)
+   
+   !Implement the calculation of the diffusion terms
+   do i=ghosts1+1,n1-ghosts1
+      Lambda_mix = alpha_turb * press(i)/(rho(i)*dphidr(i))
+      Lambda_mix = min(Lambda_mix, x1(i))
+ 
+      shear(i) = - v_turb(i)**2 * v_grad(i)
+      diss(i) = v_turb(i)**3 / Lambda_mix
+      buoy(i) = v_turb(i) * omega2_BV(i) * Lambda_mix
+
+      turb_source(i,3) = rho(i) * diss(i)
+      turb_source(i,6) = rho(i)* (shear(i) + buoy(i) - diss(i))
+
+      if (GR) then
+          turb_source(i,3) = alp(i)*X(i)*turb_source(i,3)
+          turb_source(i,6) = alp(i)*X(i)*turb_source(i,6)
+      else
+          turb_source(i,3) = sqrt_gamma(i)*turb_source(i,3)
+          turb_source(i,6) = sqrt_gamma(i)*turb_source(i,6)
+      endif
+   enddo
+ 
+end subroutine turbulence_sources
+
+subroutine Brunt_Vaisala(dts)
+
+   use GR1D_module, only: x1, v_turb, omega2_BV, GR, &
+     alpha_turb, Lambda_MLT, v1, v, dphidr, press, rho, eps, cs2, &
+     n1, ghosts1, alp, X, ishock, length_gf
+   use Grad_module
+   implicit none
+   
+   !local
+   integer i 
+   real*8 dts
+   real*8 Lambda_mix, H_P, v_turb_seed, h
+   real*8 rho_grad(n1), press_grad(n1), v_grad(n1)
+   real*8 lnrho_grad(n1), lnP_grad(n1)
+   
+   if (GR) then
+       rho_grad = Gradient_3pts(rho(:)*(1.0d0 + eps(:)),x1)
+       press_grad = Gradient_3pts(press,x1)
+       v_grad = Gradient_5pts(v,x1)
+   else
+       rho_grad = Gradient_3pts(rho,x1)
+       press_grad = Gradient_3pts(press,x1)   
+       v_grad = Gradient_5pts(v1,x1)
+       
+       !lnrho_grad = Gradient_3pts(log(rho),x1)
+       !lnP_grad = Gradient_3pts(log(press),x1)
+   endif
+   
+   do i=ghosts1+1,n1-ghosts1
+       
+      if (GR) then
+          h = 1.0d0 + eps(i) + press(i)/rho(i)
+          
+          omega2_BV(i) = alp(i)**2/(rho(i)*h*X(i)**2)* &
+                (dphidr(i) - v1(i)* v_grad(i)) * &
+                (rho_grad(i) - press_grad(i)/cs2(i))
+      else
+          omega2_BV(i) = (dphidr(i) - v(i)* v_grad(i))/rho(i)* &
+                (rho_grad(i) - press_grad(i)/cs2(i))
+      endif
+      
+      H_P = press(i)/(rho(i)*dphidr(i))
+      Lambda_mix = alpha_turb * H_P
+      Lambda_mix = min(Lambda_mix,x1(i))
+
+      Lambda_MLT(i) = Lambda_mix !store for ouptut
+
+      if (omega2_BV(i) .gt. 0.0d0) then
+          v_turb_seed = dts*omega2_BV(i)*Lambda_mix
+          v_turb(i) = max(v_turb(i),v_turb_seed)
+      endif
+
+      if ( x1(i) / length_gf .lt. 5.0d5 ) v_turb(i) = 0.0d0
+
+      ! force covective velocity to be zero in the 5 points stencil around the shock,
+      ! i.e. do not convect through the shock
+      if ( ishock(1)-2 <= i-ghosts1 .and. i-ghosts1 <= ishock(1)+2 ) v_turb(i) = 0.0d0
+
+   enddo
+
+end subroutine Brunt_Vaisala

--- a/src/turbulence.F90
+++ b/src/turbulence.F90
@@ -22,7 +22,7 @@ subroutine turb_diff_terms
       Lambda_mixp = alpha_turb * pressp(i) / (rhop(i) * dphidr(i))
       Lambda_mixp = min(Lambda_mixp,x1(i))
       
-      ! Calculate diffusion coefficients as given in Couch et al. 2019 eqs. 29-31
+      ! Calculate diffusion coefficients as given in Couch et al. 2020 eqs. 29-31
       D_turb_eps = alpha_turb_e * v_turbp(i) * Lambda_mixp
       D_turb_ye = alpha_turb_ye * v_turbp(i) * Lambda_mixp
       D_turb_K = alpha_turb_K * v_turbp(i) * Lambda_mixp


### PR DESCRIPTION
Hi Evan,
this is my implementation of STIR. There are a few things I wanted to point out that are not strictly related to STIR. Let me know if I should document the code more or what kind of changes you would like me to modify

List of changes:

- Interpolation of v1 in map_profile, let me know if that's okay (or maybe just do linear?)
- input_file is now an argument of ./GR1D. so to run the code you have to do ./GR1D parameters. Since I have to run lots of simulations, this makes it easier. Let me know what you think
- ncons is now always 6 since it has to be able to handle both rotation and turbulence. Maybe there is a better way to do it?
- in M1_explicitterms inside if(include_energycoupling_exp) one should include "h" in the OMP PARALLEL DO PRIVATE. This is a small bug I found a while ago
- I don't remember why the change in M1_implicitterms was necessary. From the comments and commits I wrote it appears that this together with forcing v_turb = 0 in the inner 5 km was done to prevent some progenitors from crashing around bounce. I would not be surprised if you were the one who suggested it 